### PR TITLE
Add instructions on how to configure preload via SecureHeaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ Start with the [Rails Security Guide](http://guides.rubyonrails.org/security.htm
 
 - Add your domain to the [HSTS Preload List](https://hstspreload.org/)
 
+  Add the following to `config/application.rb`
+
   ```ruby
-  config.ssl_options = {hsts: {subdomains: true, preload: true}}
+  SecureHeaders::Configuration.default do |config|
+    config.hsts = "max-age=#{1.year.to_i}; includeSubdomains; preload"
+  end
   ```
 
 - Protect sensitive data at rest with a library like [attr_encrypted](https://github.com/attr-encrypted/attr_encrypted)


### PR DESCRIPTION
There are several people, myself included experiencing issues with setting HSTS preload via Rails. In the latest stable release of Rails, the header will return the max-age and subdomain, but not the preload.

However if you use force_ssl and manage the hsts via SecureHeaders you'll get it working.