### PR TITLE
Add a tip on enabling Subresource Integrity for assets served from CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Also, check out [this guide](https://ankane.org/sensitive-data-rails) for securi
 
 - Don’t use assets from a public CDN, as this creates unnecessary availability and security risk
 
+  Use `integrity: true, crossorigin: "anonymous"` on `javascript_include_tag` and `stylesheet_link_tag` for assets behind CDN ([Sprockets 3.x supports this](https://github.com/rails/sprockets-rails/blob/bbfcefda3240d924260e3530f896be94cdf23034/README.md#sri-support), and see [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) & [Crossorigin attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes))
+
 ## Open Source Tools
 
 - [Brakeman](https://github.com/presidentbeef/brakeman) is a great static analysis tool - it scans your code for vulnerabilities


### PR DESCRIPTION
👋 

With this enable, asset will Include checksum that browser will validate to see if asset is compromised. Avoid XSS attack.

A requirement for [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) to work correctly is to [partner with CORS](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) (either set to `anonymous` or `use-credentials`.

Most modern browsers support this, and see also [how GitHub is using it](https://githubengineering.com/subresource-integrity/).

<kbd>[Preview Changed README](https://github.com/ankane/secure_rails/blob/b8b2b0b24c588b7800bafc23cdf8c029e82416b4/README.md)</kbd>


